### PR TITLE
Eliminate division from multiplication to bring performance equal to raw integer multiplication!

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.6
+
 Compat 1.1.0
+BitIntegers

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -512,13 +512,15 @@ Base.widen(::Type{Int128}) = Int256
 Base.widen(::Type{UInt128}) = UInt256
 Base.unsigned(::Type{Int256}) = UInt256
 Base.signed(::Type{UInt256}) = Int256
+#Base.unsigned(::Type{Int512}) = UInt512
+#Base.signed(::Type{UInt512}) = Int512
 
 nbits(::Type{T}) where {T} = sizeof(T)*8
 nbits(x::T) where {T} = nbits(T)
 
 Base.@pure function precise_inv_coeff(::Type{FD{T, f}}) where {T, f}
     # Calculate 2^128/10^18
-    invcoef = typemax(widen(unsigned(T))) ÷ T(10^f)
+    invcoef = typemax(widen(unsigned(T))) ÷ T(10)^f
     nzeros = leading_zeros(invcoef)
     # return 2^nzeros * 2^128/10^18  (shift << by nzeros)
     # So later, we need to divide by 2^128 and 2^nzeros
@@ -538,6 +540,12 @@ narrow(::Type{UInt128}) = UInt64
 narrow(::Type{UInt64}) = UInt32
 narrow(::Type{UInt32}) = UInt16
 narrow(::Type{UInt16}) = UInt8
+
+# BitInteger improvements
+Base.isodd(a::Int256) = Base.isodd(a % Int8)  # only depends on the final bit! :)
+Base.iseven(a::Int256) = Base.iseven(a % Int8)  # only depends on the final bit! :)
+Base.isodd(a::Int512) = Base.isodd(a % Int8)  # only depends on the final bit! :)
+Base.iseven(a::Int512) = Base.iseven(a % Int8)  # only depends on the final bit! :)
 
 # -------------------------------------
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -159,19 +159,25 @@ _round_to_even(q, r, d) = _round_to_even(promote(q, r, d)...)
 # TODO: can we use floating point to speed this up? after we build a
 # correctness test suite.
 function *(x::FD{T, f}, y::FD{T, f}) where {T, f}
-    inv_powt = inverse_coefficient(FD{T, f})
+    toshift, inv_powt = precise_inv_coeff(FD{T, f})
+    #inv_powt = inverse_coefficient(FD{T, f})
     firstmul = widemul(x.i, y.i)
+    #u,l = split(firstmul)
     huge_result = widemul(firstmul, inv_powt)
     #result = huge_result >> (8*sizeof(T))
-    result = rounding_bitshift(huge_result, 8*sizeof(T))
-    reinterpret(FD{T, f}, result)
+    result = rounding_bitshift(huge_result, toshift)
+    #result = huge_result >> toshift
+    reinterpret(FD{T, f}, result % T)
 end
 
 function rounding_bitshift(x::T, s::Int) where {T<:Integer}
     clipped = x >> s
-    ones = (widen(T)(2)^s - 1) % T
+    ones = shiftmask(T, s)
     return _round_to_even(clipped, (x & ones), ones)
 end
+
+Base.@pure shiftmask(::Type{T}, s::Int) where {T<:Integer} = (T(2)^s - T(1))
+
 
 
 # these functions are needed to avoid InexactError when converting from the
@@ -507,17 +513,60 @@ coefficient(::Type{FD{T, f}}) where {T, f} = T(10)^f
 coefficient(fd::FD{T, f}) where {T, f} = coefficient(FD{T, f})
 
 
-"""
-    inverse_coefficient(::Type{FD{T, f}}) -> T
 
-Compute the fractional part of `1/10^f` as a binary number, rounded to the maximum
-precision.
-"""
-function inverse_coefficient(::Type{FD{T, f}}) where {T, f}
-    rounding_bitshift(typemax(unsigned(widen(T))) ÷ T(10)^f, 8*sizeof(T))
+using BitIntegers
+Base.widen(::Type{Int128}) = Int256
+Base.widen(::Type{UInt128}) = UInt256
+Base.unsigned(::Type{Int256}) = UInt256
+Base.signed(::Type{UInt256}) = Int256
+
+# Have to compute (a*b)/10^18.
+# In hexadecimal, the reciprocal of 10^18 is:
+# 1/10^18 = 0.0000000000000012725DD1D243ABA0E75FE645CC4873F9E65AFE688C928E1F...
+# (Using 'bc' with 'obase=16 scale=128')
+# If we split this into octs, we see it is:
+#         = 0.0000000000000012 725DD1D243ABA0E7 5FE645CC4873F9E6 5AFE688C928E1F...
+# We want to use integer math to multiply by the reciprocal.  If we take the
+# leading digits:
+#         = 2^-192 * 2^8 * (12725DD1D243ABA0E75FE645CC4873F9.E65AFE688C928E1F)
+# Note that 10^36 = 0x00C097CE7BC90715 B34B9F1000000000
+# The top byte of the first oct is zero, so it is safe to shift b left by 8 bits.
+nbits(::Type{T}) where {T} = sizeof(T)*8
+nbits(x::T) where {T} = nbits(T)
+
+Base.@pure function precise_inv_coeff(::Type{FD{T, f}}) where {T, f}
+    # Calculate 2^128/10^18
+    invcoef = typemax(widen(unsigned(T))) ÷ T(10^f)
+    nzeros = leading_zeros(invcoef)
+    # return 2^nzeros * 2^128/10^18  (shift << by nzeros)
+    # So later, we need to divide by 2^128 and 2^nzeros
+    # or, shift >> by (128+nzeros)
+    return (nbits(invcoef)+nzeros), invcoef << nzeros
 end
-inverse_coefficient(fd::FD{T, f}) where {T, f} = inverse_coefficient(FD{T, f})
 
+function decmul(a,b)
+
+end
+
+# ------------------------------------
+
+function intsplit(x::T) where T
+    OutType = narrow(T)
+    OutType(x>>nbits(OutType)), x % OutType
+end
+
+narrow(::Type{Int256}) = Int128
+narrow(::Type{Int128}) = Int64
+narrow(::Type{Int64}) = Int32
+narrow(::Type{Int32}) = Int16
+narrow(::Type{Int16}) = Int8
+narrow(::Type{UInt256}) = UInt128
+narrow(::Type{UInt128}) = UInt64
+narrow(::Type{UInt64}) = UInt32
+narrow(::Type{UInt32}) = UInt16
+narrow(::Type{UInt16}) = UInt8
+
+# -------------------------------------
 
 value(fd::FD) = fd.i
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -170,13 +170,13 @@ function *(x::FD{T, f}, y::FD{T, f}) where {T, f}
     reinterpret(FD{T, f}, result % T)
 end
 
-function rounding_bitshift(x::T, s::Int) where {T<:Integer}
-    clipped = x >> s
+Base.@pure function rounding_bitshift(x::T, s::Val{N}) where {T<:Integer, N}
+    clipped = x >> N
     ones = shiftmask(T, s)
     return _round_to_even(clipped, (x & ones), ones)
 end
 
-Base.@pure shiftmask(::Type{T}, s::Int) where {T<:Integer} = (T(2)^s - T(1))
+Base.@pure shiftmask(::Type{T}, ::Val{N}) where {T<:Integer, N} = (T(2)^N - T(1))
 
 
 
@@ -541,7 +541,7 @@ Base.@pure function precise_inv_coeff(::Type{FD{T, f}}) where {T, f}
     # return 2^nzeros * 2^128/10^18  (shift << by nzeros)
     # So later, we need to divide by 2^128 and 2^nzeros
     # or, shift >> by (128+nzeros)
-    return (nbits(invcoef)+nzeros), invcoef << nzeros
+    return (Val(nbits(invcoef)+nzeros)), invcoef << nzeros
 end
 
 function decmul(a,b)

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -164,13 +164,13 @@ function *(x::FD{T, f}, y::FD{T, f}) where {T, f}
     reinterpret(FD{T, f}, result % T)
 end
 
-function rounding_bitshift(x::T, s::Val{N}) where {T<:Integer, N}
+Base.@pure function rounding_bitshift(x::T, s::Val{N}) where {T<:Integer, N}
     clipped = x >> N
     ones = shiftmask(T, s)
     return _round_to_even(clipped, (x & ones), ones)
 end
 
-shiftmask(::Type{T}, ::Val{N}) where {T<:Integer, N} = (T(2)^N - T(1))
+Base.@pure shiftmask(::Type{T}, ::Val{N}) where {T<:Integer, N} = (T(2)^N - T(1))
 
 
 
@@ -516,7 +516,7 @@ Base.signed(::Type{UInt256}) = Int256
 nbits(::Type{T}) where {T} = sizeof(T)*8
 nbits(x::T) where {T} = nbits(T)
 
-function precise_inv_coeff(::Type{FD{T, f}}) where {T, f}
+Base.@pure function precise_inv_coeff(::Type{FD{T, f}}) where {T, f}
     # Calculate 2^128/10^18
     invcoef = typemax(widen(unsigned(T))) ÷ T(10^f)
     nzeros = leading_zeros(invcoef)

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -484,6 +484,7 @@ function max_exp10(::Type{T}) where {T <: Integer}
 end
 
 max_exp10(::Type{BigInt}) = -1
+@eval max_exp10(::Type{Int128}) = $(max_exp10(Int128))  # Freeze this, because it depends on BigInt.
 
 """
     coefficient(::Type{FD{T, f}}) -> T

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -548,15 +548,6 @@ constructable `FD{T, f}`.
 coefficient(::Type{FD{T, f}}) where {T, f} = T(10)^f
 coefficient(fd::FD{T, f}) where {T, f} = coefficient(FD{T, f})
 
-
-using BitIntegers
-Base.widen(::Type{Int128}) = Int256
-Base.widen(::Type{UInt128}) = UInt256
-Base.unsigned(::Type{Int256}) = UInt256
-Base.signed(::Type{UInt256}) = Int256
-#Base.unsigned(::Type{Int512}) = UInt512
-#Base.signed(::Type{UInt512}) = Int512
-
 nbits(::Type{T}) where {T} = sizeof(T)*8
 nbits(x::T) where {T} = nbits(T)
 
@@ -571,23 +562,30 @@ Base.@pure function precise_inv_coeff(::Type{FD{T, f}}) where {T, f}
 end
 
 # ------------------------------------
-
-narrow(::Type{Int256}) = Int128
 narrow(::Type{Int128}) = Int64
 narrow(::Type{Int64}) = Int32
 narrow(::Type{Int32}) = Int16
 narrow(::Type{Int16}) = Int8
-narrow(::Type{UInt256}) = UInt128
 narrow(::Type{UInt128}) = UInt64
 narrow(::Type{UInt64}) = UInt32
 narrow(::Type{UInt32}) = UInt16
 narrow(::Type{UInt16}) = UInt8
 
-# BitInteger improvements
-Base.isodd(a::Int256) = Base.isodd(a % Int8)  # only depends on the final bit! :)
-Base.iseven(a::Int256) = Base.iseven(a % Int8)  # only depends on the final bit! :)
-Base.isodd(a::Int512) = Base.isodd(a % Int8)  # only depends on the final bit! :)
-Base.iseven(a::Int512) = Base.iseven(a % Int8)  # only depends on the final bit! :)
+#using BitIntegers
+#Base.widen(::Type{Int128}) = Int256
+#Base.widen(::Type{UInt128}) = UInt256
+#Base.unsigned(::Type{Int256}) = UInt256
+#Base.signed(::Type{UInt256}) = Int256
+##Base.unsigned(::Type{Int512}) = UInt512
+##Base.signed(::Type{UInt512}) = Int512
+#
+#narrow(::Type{Int256}) = Int128
+#narrow(::Type{UInt256}) = UInt128
+## BitInteger improvements
+#Base.isodd(a::Int256) = Base.isodd(a % Int8)  # only depends on the final bit! :)
+#Base.iseven(a::Int256) = Base.iseven(a % Int8)  # only depends on the final bit! :)
+#Base.isodd(a::Int512) = Base.isodd(a % Int8)  # only depends on the final bit! :)
+#Base.iseven(a::Int512) = Base.iseven(a % Int8)  # only depends on the final bit! :)
 
 # -------------------------------------
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -599,21 +599,21 @@ narrow(::Type{UInt64}) = UInt32
 narrow(::Type{UInt32}) = UInt16
 narrow(::Type{UInt16}) = UInt8
 
-#using BitIntegers
-#Base.widen(::Type{Int128}) = Int256
-#Base.widen(::Type{UInt128}) = UInt256
-#Base.unsigned(::Type{Int256}) = UInt256
-#Base.signed(::Type{UInt256}) = Int256
-##Base.unsigned(::Type{Int512}) = UInt512
-##Base.signed(::Type{UInt512}) = Int512
-#
-#narrow(::Type{Int256}) = Int128
-#narrow(::Type{UInt256}) = UInt128
-## BitInteger improvements
-#Base.isodd(a::Int256) = Base.isodd(a % Int8)  # only depends on the final bit! :)
-#Base.iseven(a::Int256) = Base.iseven(a % Int8)  # only depends on the final bit! :)
-#Base.isodd(a::Int512) = Base.isodd(a % Int8)  # only depends on the final bit! :)
-#Base.iseven(a::Int512) = Base.iseven(a % Int8)  # only depends on the final bit! :)
+using BitIntegers
+Base.widen(::Type{Int128}) = Int256
+Base.widen(::Type{UInt128}) = UInt256
+Base.unsigned(::Type{Int256}) = UInt256
+Base.signed(::Type{UInt256}) = Int256
+#Base.unsigned(::Type{Int512}) = UInt512
+#Base.signed(::Type{UInt512}) = Int512
+
+narrow(::Type{Int256}) = Int128
+narrow(::Type{UInt256}) = UInt128
+# BitInteger improvements
+Base.isodd(a::Int256) = Base.isodd(a % Int8)  # only depends on the final bit! :)
+Base.iseven(a::Int256) = Base.iseven(a % Int8)  # only depends on the final bit! :)
+Base.isodd(a::Int512) = Base.isodd(a % Int8)  # only depends on the final bit! :)
+Base.iseven(a::Int512) = Base.iseven(a % Int8)  # only depends on the final bit! :)
 
 # -------------------------------------
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -160,22 +160,16 @@ _round_to_even(q, r, d) = _round_to_even(promote(q, r, d)...)
 # correctness test suite.
 function *(x::FD{T, f}, y::FD{T, f}) where {T, f}
     inv_powt = inverse_coefficient(FD{T, f})
-    @show inv_powt
     firstmul = widemul(x.i, y.i)
-    @show firstmul
     huge_result = widemul(firstmul, inv_powt)
-    @show huge_result
     #result = huge_result >> (8*sizeof(T))
     result = rounding_bitshift(huge_result, 8*sizeof(T))
-    @show result
     reinterpret(FD{T, f}, result)
 end
 
 function rounding_bitshift(x::T, s::Int) where {T<:Integer}
-    @show s
     clipped = x >> s
-    @show clipped
-    ones = widen(T)(2)^s - 1
+    ones = (widen(T)(2)^s - 1) % T
     return _round_to_even(clipped, (x & ones), ones)
 end
 

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -158,15 +158,20 @@ _round_to_even(q, r, d) = _round_to_even(promote(q, r, d)...)
 # multiplication rounds to nearest even representation
 function decmul_positive(xi::T, yi::T, ::Val{f}) where {T<:Unsigned, f}
     toshift, inv_powt = precise_inv_coeff(FD{T, f})
+    #@show inv_powt
+    #@show toshift
     firstmul = widemul(xi, yi)
     #rup, rlo = splitwidemul(firstmul, inv_powt)
     huge_result = widemul(firstmul, inv_powt)
+    #huge_result = round(huge_result, digits = ndigits(xi), base=2)
     #huge_result = unsplitint(rup,rlo)
     #@show toshift
     #@show huge_result
+    shiftedresult = rounding_bitshift(huge_result, Val(nbits(inv_powt)))
+    #@show shiftedresult
     #result = constshift(rup, toshift) + constshift_remainder(rup, toshift, rlo)
     #result = constshift(rup, toshift_up) + constshift(rlo, toshift_lo)
-    result = rounding_bitshift(huge_result, toshift)
+    result = rounding_bitshift(shiftedresult, toshift)
     #result = constshift(huge_result, toshift)
     return result
 end
@@ -201,11 +206,24 @@ end
 
 Base.@pure function rounding_bitshift(x::T, s::Val{N}) where {T<:Integer, N}
     clipped = x >> N
-    divisor = (one(T)+one(T))^N
-    ones = shiftmask(T, s)
+    divisor = (one(T)+one(T))^N  # Const
+    ones = shiftmask(T, s)  # Const
     remainder = (x & ones)
+    #@show clipped, remainder, divisor
     return _round_to_even(clipped, remainder, divisor)
 end
+
+#function _round_to_even_with_even_divisor(quotient::T, remainder::T, divisor::T) where {T <: Integer}
+#    halfdivisor = divisor >> 1
+#    # We know the divisor is always even since we're dividing by 2^N
+#    if #= iseven(divisor) && =# remainder == halfdivisor
+#        ifelse(iseven(quotient), quotient, quotient + one(quotient))
+#    elseif abs(remainder) > abs(halfdivisor)
+#        quotient + one(quotient)
+#    else
+#        quotient
+#    end
+#end
 
 Base.@pure shiftmask(::Type{T}, ::Val{N}) where {T<:Integer, N} = (T(2)^N - T(1))
 
@@ -585,12 +603,16 @@ nbits(x::T) where {T} = nbits(T)
 
 Base.@pure function precise_inv_coeff(::Type{FD{T, f}}) where {T, f}
     # Calculate 2^128/10^18
-    invcoef = typemax(widen(unsigned(T))) ÷ T(10)^f
-    nzeros = leading_zeros(invcoef)
+    WT = widen(unsigned(T))
+    WWT = widen(WT)
     # return 2^nzeros * 2^128/10^18  (shift << by nzeros)
+    invcoef = typemax(WWT) ÷ WWT(10)^f
+    nzeros = leading_zeros(invcoef)
+    invcoef = invcoef << nzeros
+    invcoef = WT(invcoef >> nbits(WT))
     # So later, we need to divide by 2^128 and 2^nzeros
     # or, shift >> by (128+nzeros)
-    return Val(nbits(invcoef) + nzeros), invcoef << nzeros
+    return Val(#=nbits(invcoef) +=# nzeros), invcoef
 end
 
 # ------------------------------------

--- a/src/int256-ops.jl
+++ b/src/int256-ops.jl
@@ -1,0 +1,153 @@
+using BitIntegers
+
+Base.widen(::Type{Int128}) = Int256
+
+# =========================================
+# ======= Add Int256 division =============
+# =========================================
+a = 323423242342; b = 231
+FloatType = Float64; T=typeof(a)
+b = typeof(a)(b)
+nothing
+function iterative_float_div(FloatType::Type{<:Real}, a::T, b::T) where {T<:Integer}
+    #a,b = widen(a), widen(b)
+    #T=typeof(a)
+    @assert b != 0
+    bfloat = convert(FloatType, b)
+    r = one(FloatType)/bfloat
+
+    residual = a
+    result = zero(a)
+
+    while (abs(residual) >= abs(b))
+        residual_float = convert(FloatType, residual)
+        c = residual_float * r
+        residual_approx = convert(T, trunc(c))
+        result += residual_approx
+        approx = residual_approx * b
+        residual -= approx
+    end
+
+    return result
+end
+iterative_float_div(FloatType::Type{<:Real}, a::T,b::U) where{T<:Integer, U<:Integer} = iterative_float_div(FloatType, promote(a,b)...)
+
+# Converted from Float64(::Int128) here:
+# https://github.com/JuliaLang/julia/blob/master/base/float.jl#L94
+# Note that the implementations are almost identical, save for how many bits to shift.
+function Float64(x::Int256)
+    x == 0 && return 0.0
+    s = ((x >>> (256-64)) % UInt64) & 0x8000_0000_0000_0000 # sign bit
+    x = abs(x) % UInt256
+    n = 256-leading_zeros(x) # ndigits0z(x,2)
+    if n <= 53  # Mantissa (significand) has 53 bytes.
+        y = ((x % UInt64) << (53-n)) & 0x000f_ffff_ffff_ffff
+    else
+        y = ((x >> (n-54)) % UInt64) & 0x001f_ffff_ffff_ffff # keep 1 extra bit
+        y = (y+1)>>1 # round, ties up (extra leading bit in case of next exponent)
+        y &= ~UInt64(trailing_zeros(x) == (n-54)) # fix last bit to round to even
+    end
+    d = ((n+1022) % UInt64) << 52
+    reinterpret(Float64, s | d + y)
+end
+Float64(Int128(-2))
+Float64(Int256(-2))
+Float64(Int128(2))
+Float64(Int256(2))
+Float64(typemax(Int128))
+Float64(Int256(typemax(Int128)))
+Float64(Int256(typemax(Int128))*2)
+Float64(-Int256(typemax(Int128))*2)
+Float64(typemax(Int256)) ≈ typemax(Int256)
+
+
+# ----------------------------
+
+# Copied exactly from the definition for unsafe_trunc(::UInt128, ::Float64):
+# https://github.com/JuliaLang/julia/blob/master/base/float.jl#L315
+# The implementations are identical, since the size of the output is irrelevant in the calculations.
+function Base.unsafe_trunc(::Type{UInt256}, x::Float64)
+    xu = reinterpret(UInt64,x)
+    k = Int(xu >> 52) & 0x07ff - 1075
+    xu = (xu & 0x000f_ffff_ffff_ffff) | 0x0010_0000_0000_0000
+    if k <= 0
+        UInt256(xu >> -k)
+    else
+        UInt256(xu) << k
+    end
+end
+function Base.unsafe_trunc(::Type{Int256}, x::Float64)
+    copysign(unsafe_trunc(UInt256,x) % Int256, x)
+end
+
+for Ti in (UInt256, Int256)
+    for Tf in (Float32, Float64)
+        if Ti <: Unsigned || sizeof(Ti) < sizeof(Tf)
+            @eval begin
+                function (::Type{$Ti})(x::$Tf)
+                    if ($(Tf(typemin(Ti))) <= x <= $(Tf(typemax(Ti)))) && (round(x, RoundToZero) == x)
+                        return unsafe_trunc($Ti,x)
+                    else
+                        throw(InexactError($(Expr(:quote,Ti.name.name)), $Ti, x))
+                    end
+                end
+            end
+        else
+            @eval begin
+                function (::Type{$Ti})(x::$Tf)
+                    if ($(Tf(typemin(Ti))) <= x < $(Tf(typemax(Ti)))) && (round(x, RoundToZero) == x)
+                        return unsafe_trunc($Ti,x)
+                    else
+                        throw(InexactError($(Expr(:quote,Ti.name.name)), $Ti, x))
+                    end
+                end
+            end
+        end
+    end
+end
+
+
+#using BenchmarkTools
+#for T in (Int8,Int16,Int32,Int64,Int128,Int256)
+#    a = abs(rand(T))
+#    b = T(trunc(sqrt(a)))
+#    println(T)
+#    v = @btime iterative_float_div(Float64,$a,$b)
+#    v = @btime $a ÷ $b
+#    @assert a÷b == v
+#end
+
+# Now that we've shown they're equivalent, let's use iterative_float_div for div:
+Base.div(a::Int256,b::Int256) = iterative_float_div(Float64, a, b)
+
+# =========================================
+# ======= Add Int256 rem =============
+# =========================================
+
+#  need `rem` to fix all the BigInts in FixedDecimal{Int128} multiplication!
+# TODO: is this good enough? We could probably do faster?
+function float_rem(FloatType::Type{<:Real}, a::T, b::T) where {T<:Integer}
+    a - ((a ÷ b) * b)
+end
+
+Base.rem(a::Int256, b::Int256) = float_rem(Float64, a, b)
+
+# Custom divrem to prevent doing the `div` twice (it's expensive).
+function Base.divrem(a::Int256, b::Int256)
+    d = div(a,b)
+    r = a - (d * b)
+    return d,r
+end
+# Custom fldmod to prevent doing the `div` twice (it's expensive).
+function Base.fldmod(a::Int256, b::Int256)
+    d = fld(a,b)
+    r = a - (d * b)
+    return d,r
+end
+Base.fldmod(a::Int256, b::Integer) = fldmod(promote(a,b)...)
+Base.fldmod(a::Integer, b::Int256) = fldmod(promote(a,b)...)
+
+# Prevent unneeded rem call here:
+function Base.isodd(a::Int256)
+    return Base.isodd(a % Int8)  # only depends on the final bit! :)
+end

--- a/test/fuzz-tests.jl
+++ b/test/fuzz-tests.jl
@@ -1,0 +1,53 @@
+using FixedPointDecimals
+import FixedPointDecimals: FD, value
+
+using Test
+
+numdigits = 9
+FD64 = FD{Int64, numdigits}
+
+bigfloat_min = BigFloat(typemin(FD64))/2
+bigfloat_max = BigFloat(typemax(FD64))/2
+bigfloat_range = range(bigfloat_min,length=100_000,stop=bigfloat_max)
+
+
+@testset "Fuzz tests" begin
+    N = 10_000
+
+    @testset "+" begin
+        for _ in 1:N
+            a,b = round.(rand(bigfloat_range, 2), digits=numdigits)
+            @test FD64(a + b) == FD64(a) + FD64(b)
+        end
+    end
+    @testset "-" begin
+        for _ in 1:N
+            a,b = round.(rand(bigfloat_range, 2), digits=numdigits)
+            @test FD64(a - b) == FD64(a) - FD64(b)
+        end
+    end
+    @testset "*" begin
+        for _ in 1:N
+            # Choose random numbers a,b to prevent overflow:
+            # Choose a random number of digits for a, then a random number of digits for b
+            # such at digits(a) + digits(b) <= (numdigits-1)
+            adigits = rand(1:numdigits-1)
+            bdigits = numdigits-adigits-1
+            rand_ndigits(ndigits) = rand(range(big"1.0", stop=big"10.0"^(ndigits), length=10000)) * (rand()>0.5 ? -1 : 1)
+            a,b = round.(rand_ndigits.((adigits,bdigits)), digits=numdigits)
+            @test FD64(a * b) == FD64(a) * FD64(b)
+        end
+    end
+    @testset "/" begin
+        for _ in 1:N
+            a,b = round.(rand(bigfloat_range/10^(numdigits/2), 2), digits=numdigits)
+            @test FD64(a / b) == FD64(a) / FD64(b)
+        end
+    end
+    @testset "÷" begin
+        for _ in 1:N
+            a,b = round.(rand(bigfloat_range, 2), digits=numdigits)
+            @test FD64(a ÷ b) == FD64(a) ÷ FD64(b)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -967,3 +967,7 @@ end
 end
 
 end  # global testset
+
+# This is outside the global testset so that we only run the fuzz tests if all
+# the normal tests passed.
+include("fuzz-tests.jl")


### PR DESCRIPTION
Opening this PR to have a place to discuss @tveldhui's super clever bitshift trick to avoid the division by 10^18!

I've generalized it to work for any type T, and any precision, `f` here. :)

Here's the summary:

1. Division is expensive, and should be avoided.
2. Since all of our numbers are represented as being multiplied by 10^f  (4.00 is stored as 400), when you multiply them together, you must divide by 10^f again (4.00*2.00 ==> 400*200 ==> 80000 ; 80000/100 ==> 800 ==> 8.00)
3. Restating the above, the algorithm for multiplication is:
      a. `widemul(a,b) / 10^f`
4. In order to prevent the division, we can multiply the expression from 3a above by `2^32/2^32` (where 32 is the number of bits in T, our storage type) to get:
     a. `widemul(a,b) * (2^32 / 10^f)  / 2^32`
5. `(2^32 / 10^f)` can be precomputed statically based on only type information, so it is simply multiplying by a constant, giving:
     a. `widemul(a,b) * _constant_  / 2^32`
6. And now division by a power of two can be performed via bitshift, yielding:
     a. `widemul(a,b) * _constant_  >> 2^32`

There's one more trick which relates to precision, which is that the constant  `(2^32 / 10^f)`, which is really `(2^(nbits(T)) / 10^f)`, can have lots of leading zeros if `f` is large, leading to a loss in precision.
So we can shift the constant by `N = leadingzeros(_constant_)`, and then just add that `N` to the final bits to shift, giving us the complete algorithm:

```julia
invcoef = (2^(nbits(T)) / 10^f)
N = leading_zeros(invcoef)
return widemul(a,b) * invcoef  >> 2^(nbits(T) + N)
```