### PR TITLE
Use widen(Int128)=BitIntgers.Int256 within FD

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 Compat 1.1.0
+BitIntegers

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -44,13 +44,19 @@ include("fldmod_by_const.jl")
 
 import BitIntegers
 
+# ---------- Necessary Extensions -----------------------
+# TODO: delete these once https://github.com/rfourquet/BitIntegers.jl/pull/2 and
+# https://github.com/rfourquet/BitIntegers.jl/pull/3 are merged.
+
 # BitIntegers is missing unsigned(::Type{Int256})
-Base.unsigned(x::T) where T<:BitIntegers.XBS = reinterpret(unsigned(T), x)
-Base.unsigned(::Type{T}) where T<:BitIntegers.XBS = typeof(convert(Unsigned, zero(T)))
+# XBI == Union{BitIntegers.AbstractBitSigned, BitIntegers.AbstractBitUnsigned}
+Base.unsigned(::Type{T}) where T<:BitIntegers.XBI = typeof(convert(Unsigned, zero(T)))
+Base.unsigned(x::T) where T<:BitIntegers.XBI = reinterpret(unsigned(T), x)
 
 # BitIntegers is missing iseven/isodd
-# Prevent expensive calculation for Int256
+# Prevent expensive calculation for Int256. Needed since `_round_to_even` calls `iseven`.
 Base.isodd(a::BitIntegers.Int256) = Base.isodd(a % Int)  # only depends on the final bit! :)
+# -------------------------------------------------------
 
 _widen(T::Type) = widen(T)
 _widen(x::T) where {T} = (_widen(T))(x)

--- a/src/FixedPointDecimals.jl
+++ b/src/FixedPointDecimals.jl
@@ -38,6 +38,31 @@ import Base: reinterpret, zero, one, abs, sign, ==, <, <=, +, -, /, *, div, rem,
 
 include("fldmod_by_const.jl")
 
+# =========================================================
+# Set Int128 to widen to Int256 within FixedPointDecimals to avoid allocations from BigInt.
+# ---------------------------------------
+
+import BitIntegers
+
+# BitIntegers is missing unsigned(::Type{Int256})
+Base.unsigned(x::T) where T<:BitIntegers.XBS = reinterpret(unsigned(T), x)
+Base.unsigned(::Type{T}) where T<:BitIntegers.XBS = typeof(convert(Unsigned, zero(T)))
+
+# BitIntegers is missing iseven/isodd
+# Prevent expensive calculation for Int256
+Base.isodd(a::BitIntegers.Int256) = Base.isodd(a % Int)  # only depends on the final bit! :)
+
+_widen(T::Type) = widen(T)
+_widen(x::T) where {T} = (_widen(T))(x)
+_widen(::Type{Int128}) = BitIntegers.Int256
+_widen(::Type{UInt128}) = BitIntegers.UInt256
+
+_widemul(a,b) = _widen(a)*_widen(b)
+
+narrow(::Type{BitIntegers.Int256}) = Int128
+narrow(::Type{BitIntegers.UInt256}) = UInt128
+# =========================================================
+
 const BitInteger = Union{Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64,
                          UInt64, Int128, UInt128}
 
@@ -127,11 +152,11 @@ abs(x::FD{T, f}) where {T, f} = reinterpret(FD{T, f}, abs(x.i))
 
 # wide multiplication
 Base.@pure function widemul(x::FD{<:Any, f}, y::FD{<:Any, g}) where {f, g}
-    i = widemul(x.i, y.i)
+    i = _widemul(x.i, y.i)
     reinterpret(FD{typeof(i), f + g}, i)
 end
 Base.@pure function widemul(x::FD{T, f}, y::Integer) where {T, f}
-    i = widemul(x.i, y)
+    i = _widemul(x.i, y)
     reinterpret(FD{typeof(i), f}, i)
 end
 Base.@pure widemul(x::Integer, y::FD) = widemul(y, x)
@@ -167,7 +192,7 @@ _round_to_even(q, r, d) = _round_to_even(promote(q, r, d)...)
 # correctness test suite.
 function *(x::FD{T, f}, y::FD{T, f}) where {T, f}
     powt = coefficient(FD{T, f})
-    quotient, remainder = custom_fldmod(widemul(x.i, y.i), powt)
+    quotient, remainder = custom_fldmod(_widemul(x.i, y.i), powt)
     reinterpret(FD{T, f}, _round_to_even(quotient, remainder, powt))
 end
 
@@ -188,7 +213,7 @@ end
 
 function /(x::FD{T, f}, y::FD{T, f}) where {T, f}
     powt = coefficient(FD{T, f})
-    quotient, remainder = fldmod(widemul(x.i, powt), y.i)
+    quotient, remainder = fldmod(_widemul(x.i, powt), y.i)
     reinterpret(FD{T, f}, T(_round_to_even(quotient, remainder, y.i)))
 end
 
@@ -196,8 +221,8 @@ end
 # FixedDecimal.
 function /(x::Integer, y::FD{T, f}) where {T, f}
     powt = coefficient(FD{T, f})
-    powtsq = widemul(powt, powt)
-    quotient, remainder = fldmod(widemul(x, powtsq), y.i)
+    powtsq = _widemul(powt, powt)
+    quotient, remainder = fldmod(_widemul(x, powtsq), y.i)
     reinterpret(FD{T, f}, T(_round_to_even(quotient, remainder, y.i)))
 end
 
@@ -292,7 +317,7 @@ end
 convert(::Type{FD{T, f}}, x::FD{T, f}) where {T, f} = x  # Converting an FD to itself is a no-op
 
 function convert(::Type{FD{T, f}}, x::Integer) where {T, f}
-    reinterpret(FD{T, f}, T(widemul(x, coefficient(FD{T, f}))))
+    reinterpret(FD{T, f}, T(_widemul(x, coefficient(FD{T, f}))))
 end
 
 convert(::Type{T}, x::AbstractFloat) where {T <: FD} = round(T, x)
@@ -306,7 +331,7 @@ function convert(::Type{FD{T, f}}, x::FD{U, g}) where {T, f, U, g}
     if f ≥ g
         # Compute `10^(f - g)` without overflow
         powt = div(coefficient(FD{T, f}), coefficient(FD{U, g}))
-        reinterpret(FD{T, f}, T(widemul(x.i, powt)))
+        reinterpret(FD{T, f}, T(_widemul(x.i, powt)))
     else
         # Compute `10^(g - f)` without overflow
         powt = div(coefficient(FD{U, g}), coefficient(FD{T, f}))
@@ -489,7 +514,7 @@ types of `T` that do not overflow -1 will be returned.
 # state. The value will never change for a given (type,precision) pair.
 # This allows its result to be const-folded away when called with Const values.
 Base.@pure function max_exp10(::Type{T}) where {T <: Integer}
-    W = widen(T)
+    W = _widen(T)
     type_max = W(typemax(T))
 
     powt = one(W)

--- a/src/fldmod_by_const.jl
+++ b/src/fldmod_by_const.jl
@@ -23,7 +23,6 @@ Base.@pure function calculate_inv_coeff(::Type{T}, f) where {T}
 end
 # These are needed to handle Int128, which widens to BigInt, since BigInt doesn't have typemax
 twoToTheSizeOf(::Type{T}) where {T} = typemax(widen(unsigned(T)))
-twoToTheSizeOf(::Union{Type{Int128}, Type{UInt128}}) = BigInt(2)^256
 twoToTheSizeOf(::Type{BigInt}) = BigInt(2)^256
 
 # This special-purpose leading_zeros is needed to handle Int128, which widens to BigInt
@@ -61,10 +60,10 @@ nbits(x) = sizeof(x)*8
     halfT = typeof(ah)
     halfbits = nbits(al)
     # /* compute partial products */
-    p0 = widemul(al, bl);
-    p1 = widemul(al, bh);
-    p2 = widemul(ah, bl);
-    p3 = widemul(ah, bh);
+    p0 = _widemul(al, bl);
+    p1 = _widemul(al, bh);
+    p2 = _widemul(ah, bl);
+    p3 = _widemul(ah, bh);
     # /* sum partial products */
     carry = ((p0 >> halfbits) + (p1%halfT) + (p2%halfT)) >> halfbits;
     return p3 + (p2 >> halfbits) + (p1 >> halfbits) + carry;

--- a/src/fldmod_by_const.jl
+++ b/src/fldmod_by_const.jl
@@ -21,11 +21,11 @@ Base.@pure function calculate_inv_coeff(::Type{T}, f) where {T}
     invcoeff = _round_to_even(fldmod(invcoeff, typemax(UT))..., typemax(UT)) % T
     return invcoeff, toshift
 end
-# These are needed to handle Int128, which widens to BigInt, since BigInt doesn't have typemax
-twoToTheSizeOf(::Type{T}) where {T} = typemax(widen(unsigned(T)))
+# These are needed to handle BigInt, since BigInt doesn't have typemax
+twoToTheSizeOf(::Type{T}) where {T} = typemax(_widen(unsigned(T)))
 twoToTheSizeOf(::Type{BigInt}) = BigInt(2)^256
 
-# This special-purpose leading_zeros is needed to handle Int128, which widens to BigInt
+# This special-purpose leading_zeros is needed to handle BigInt
 _leading_zeros(x) = leading_zeros(x)
 # BigInt doesn't have a concept of "leading zeros", but since we _know_ the value being
 # passed here will fit in 256-bits (per twoToTheSizeOf), we can pretend this is a 256-bit


### PR DESCRIPTION
Remove allocations for FD{Int128} by switching to widen to Int256 instead of BigInt.

Adds a dependency on the BitIntegers package, but it seems worth it to me.

I'm merging this into https://github.com/RelationalAI-oss/FixedPointDecimals.jl/pull/5, so that we can review them in two chunks.